### PR TITLE
Add optimizations for the deployment process at our institute

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,10 @@ jobs:
         uses: wei/curl@master
         with:
           args: -X POST --header '${{ secrets.GITLAB_PULL_HEADER }}' https://gitlab.cs.uni-duesseldorf.de/api/v4/projects/1581/mirror/pull
+      - name: Wait so that GitLab can pull latest changes before triggering the CI/CD process
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '10s'
       - name: Trigger Gitlab CI/CD
         uses: wei/curl@master
         with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,13 @@
+build_image:
+  image: docker:git
+  stage: build
+  services:
+    - docker:dind
+  script:
+    - docker login -u gitlab-ci-token -p $CI_BUILD_TOKEN $CI_REGISTRY
+    - docker build -t $CI_REGISTRY_IMAGE --pull .
+    - docker push $CI_REGISTRY_IMAGE
+
 check:
   image: gradle:jdk11
   stage: test

--- a/README.adoc
+++ b/README.adoc
@@ -57,7 +57,7 @@ https://hub.docker.com/repository/docker/cmeter/url-shortener
 There is a `docker-compose.yml` file to create a production build.
 Please copy and edit `skeleton.env` to your needs and save it as `production.env`
 
-The application then starts a redis server, which persists the data and exposes port 5007 for further access.
+The application then starts a redis server, which persists the data and exposes port 8080 for further access.
 
 == Contribution
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,6 @@ services:
   web:
     image: cmeter/url-shortener
     ports:
-      - "5007:8080"
+      - "8080:8080"
     env_file:
       - production.env


### PR DESCRIPTION
Shorty is being deployed on each push to master. The production build is always running at our university. And I do not want to have separate repositories. So some custom deployment information are being added.